### PR TITLE
JIRA client exceptions may be pushed to external error handling services

### DIFF
--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -110,7 +110,6 @@ abstract class AbstractRequest
                 case 404:
                     throw new JiraNotFoundException($message, 404, $exception);
                 default:
-                    \Log::error($exception);
                     throw new JiraClientException($message, $exception->getCode(), $exception);
             }
         }


### PR DESCRIPTION
I use Rollbar to handle errors and exceptions for my Laravel application. Due to an explicit Log::error when a JiraClientException is thrown this ends with the original exception being pushed to Rollbar.  I'm presuming this is the same behaviour for anyone using services such as Bugsnag, Sentry etc.