### PR TITLE
Missing OAuth dependency added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": ">=5.6.4",
         "laravel/framework": ">=5.4",
         "guzzlehttp/guzzle": "^6.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "guzzlehttp/oauth-subscriber": "^0.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52f6e2e402a5f55d01e0bce6c1b78170",
+    "content-hash": "cf3d9e3b6d4a3c2eb7eb593dc98ae305",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -290,6 +290,57 @@
                 "web service"
             ],
             "time": "2017-06-22T18:50:49+00:00"
+        },
+        {
+            "name": "guzzlehttp/oauth-subscriber",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/oauth-subscriber.git",
+                "reference": "04960cdef3cd80ea401d6b0ca8b3e110e9bf12cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/oauth-subscriber/zipball/04960cdef3cd80ea401d6b0ca8b3e110e9bf12cf",
+                "reference": "04960cdef3cd80ea401d6b0ca8b3e110e9bf12cf",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "~6.0",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Subscriber\\Oauth\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle OAuth 1.0 subscriber",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "oauth"
+            ],
+            "time": "2015-08-15T19:44:28+00:00"
         },
         {
             "name": "guzzlehttp/promises",


### PR DESCRIPTION
```
Class 'GuzzleHttp\Subscriber\Oauth\Oauth1' not found
```
in https://github.com/rjvandoesburg/laravel-jira-rest-client/blob/master/src/Requests/Middleware/OAuthMiddleware.php.

Solved by:
```
composer require guzzlehttp/oauth-subscriber
```