### PR TITLE
parameter fix for error on rest/api/3/user/search?username= no result

### DIFF
--- a/src/Requests/User/Parameters/SearchParameters.php
+++ b/src/Requests/User/Parameters/SearchParameters.php
@@ -40,12 +40,12 @@ class SearchParameters extends AbstractParameters
      *
      * @var bool
      */
-    public $includeActive = true;
+    public $includeActiveUsers = true;
 
     /**
      * If true, then inactive users are included in the results
      *
      * @var bool
      */
-    public $includeInactive = false;
+    public $includeInactiveUsers = false;
 }


### PR DESCRIPTION
When you try to user the api call: rest/api/3/user/search?username=% you got no results. I checked the  issue and is triggered because the includeActive and includeInactive attributes. Those must be includeActiveUsers and includeInactiveUsers instead. 