### PR TITLE
Adds the Basic Api Token middleware

### DIFF
--- a/src/Config/jira.php
+++ b/src/Config/jira.php
@@ -26,6 +26,13 @@ return [
 
             'middleware' => \Atlassian\JiraRest\Requests\Middleware\OAuthMiddleware::class,
         ],
+
+        'basic_token' => [
+            'username' => env('JIRA_USER'),
+            'token' => env('JIRA_API_TOKEN'),
+
+            'middleware' => \Atlassian\JiraRest\Requests\Middleware\BasicApiTokenMiddleware::class,
+        ],
     ],
 
     'log_level' => env('JIRA_LOG_LEVEL', 'WARNING'),

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -40,6 +40,10 @@ abstract class AbstractRequest
                     $middleware = config('atlassian.jira.auth.oauth.middleware', \Atlassian\JiraRest\Requests\Middleware\OAuthMiddleware::class);
                     $this->addMiddleware($middleware , 'auth');
                     break;
+                case 'basic_token':
+                    $middleware = config('atlassian.jira.auth.basic_token.middleware', \Atlassian\JiraRest\Requests\Middleware\BasicApiTokenMiddleware::class);
+                    $this->addMiddleware($middleware , 'auth');
+                    break;
                 case 'session':
                     // TODO: implement session default middleware
                     break;

--- a/src/Requests/Middleware/BasicApiTokenMiddleware.php
+++ b/src/Requests/Middleware/BasicApiTokenMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Atlassian\JiraRest\Requests\Middleware;
+
+use Closure;
+
+class BasicApiTokenMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param $options
+     * @param \Closure $next
+     *
+     * @return mixed
+     */
+    public function handle($options, Closure $next)
+    {
+        $authorizationHeader = base64_encode(
+            config('atlassian.jira.auth.basic_token.username').':'.config('atlassian.jira.auth.basic_token.token')
+        );
+        
+        $options['headers']['Authorization'] = 'Basic ' . $authorizationHeader;
+
+        return $next($options);
+    }
+}


### PR DESCRIPTION
Hi,

I couldn't get authenticated with only my username and password. I've read in Jira documentation that this is caused by using two factor authentication. 

So I went to search for a different approach other then OAuth and i found the possibility to create an API Token and send this as an Authorization header.

https://developer.atlassian.com/cloud/jira/service-desk/jira-rest-api-basic-authentication/ section "Supplying basic auth headers"

This pull request will add the middleware that provides this header and adds the option to the config file. 