### PR TITLE
Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.6.4",
         "laravel/framework": "*",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0|^7",
         "ext-json": "*"
     },
     "autoload": {


### PR DESCRIPTION
Hey -- I added an issue some weeks ago regarding Laravel 8 support. So I forked it, and it seems that just adding guzzle 7 allows you to install your package on Laravel 8.