### PR TITLE
Adding support for guzzle/psr7 above 2.0.0

### DIFF
--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -96,7 +96,7 @@ abstract class AbstractRequest
      */
     public function getRequestUrl($resource)
     {
-        return Psr7\uri_for($this->getApi().'/'.$resource);
+        return Psr7\Utils::uriFor($this->getApi().'/'.$resource);
     }
 
     /**
@@ -213,7 +213,7 @@ abstract class AbstractRequest
     protected function getJiraHost()
     {
         $host = config('atlassian.jira.host');
-        $uri = Psr7\uri_for($host);
+        $uri = Psr7\Utils::uriFor($host);
 
         return $uri->getHost();
     }


### PR DESCRIPTION
Since psr7 release 2.0.0 the function API was removed and replaced with a static API. See https://github.com/guzzle/psr7#upgrading-from-function-api
With newer laravel projects the new psr7 will be used an the module breaks down.

The plugin will throw a function not found error on every request 